### PR TITLE
Add unit tests for default c-tor, parametric c-tor, star operator.

### DIFF
--- a/homework/unique_ptr/CMakeLists.txt
+++ b/homework/unique_ptr/CMakeLists.txt
@@ -10,8 +10,6 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
-add_executable(${PROJECT_NAME} main.cpp)
-
 add_executable(${PROJECT_NAME}-ut Tests/testsMain.cpp Tests/tests.cpp)
 target_link_libraries(${PROJECT_NAME}-ut PRIVATE gtest_main gmock_main pthread)
 

--- a/homework/unique_ptr/Tests/tests.cpp
+++ b/homework/unique_ptr/Tests/tests.cpp
@@ -118,5 +118,5 @@ TEST(unique_ptr, star_operator) {
     auto ptr = new int{5};
     auto smartPtr = UniquePointer<int>(ptr);
 
-    EXPECT_EQ(*ptr, *smartPtr.get());
+    EXPECT_EQ(*ptr, *smartPtr);
 }

--- a/homework/unique_ptr/Tests/tests.cpp
+++ b/homework/unique_ptr/Tests/tests.cpp
@@ -10,6 +10,13 @@ public:
     MOCK_METHOD(void, Destructor, (), (noexcept));
 };
 
+TEST(unique_ptr, destructor) {
+    auto ptr = new TestObject();
+    auto smartPtr = UniquePointer<TestObject>(ptr);
+
+    EXPECT_CALL(*ptr, Destructor).Times(1);
+}
+
 TEST(unique_ptr, default_constructor) {
     auto smartPtr = UniquePointer<TestObject>();
 
@@ -21,13 +28,6 @@ TEST(unique_ptr, parametric_constructor) {
     auto smartPtr = UniquePointer<int>(ptr);
 
     EXPECT_EQ(ptr, smartPtr.get());
-}
-
-TEST(unique_ptr, destructor) {
-    auto ptr = new TestObject();
-    auto smartPtr = UniquePointer<TestObject>(ptr);
-
-    EXPECT_CALL(*ptr, Destructor).Times(1);
 }
 
 TEST(unique_ptr, get) {

--- a/homework/unique_ptr/Tests/tests.cpp
+++ b/homework/unique_ptr/Tests/tests.cpp
@@ -30,13 +30,6 @@ TEST(unique_ptr, parametric_constructor) {
     EXPECT_EQ(ptr, smartPtr.get());
 }
 
-TEST(unique_ptr, get) {
-    auto ptr = new int{5};
-    auto smartPtr = UniquePointer<int>(ptr);
-
-    EXPECT_EQ(ptr, smartPtr.get());
-}
-
 TEST(unique_ptr, reset) {
     auto ptr = new int{5};
     auto smartPtr = UniquePointer<int>(ptr);

--- a/homework/unique_ptr/Tests/tests.cpp
+++ b/homework/unique_ptr/Tests/tests.cpp
@@ -10,33 +10,46 @@ public:
     MOCK_METHOD(void, Destructor, (), (noexcept));
 };
 
-TEST(unique_ptr, destructor_test) {
+TEST(unique_ptr, default_constructor) {
+    auto smartPtr = UniquePointer<TestObject>();
+
+    EXPECT_EQ(nullptr, smartPtr.get());
+}
+
+TEST(unique_ptr, parametric_constructor) {
+    auto ptr = new int{5};
+    auto smartPtr = UniquePointer<int>(ptr);
+
+    EXPECT_EQ(ptr, smartPtr.get());
+}
+
+TEST(unique_ptr, destructor) {
     auto ptr = new TestObject();
     auto smartPtr = UniquePointer<TestObject>(ptr);
 
     EXPECT_CALL(*ptr, Destructor).Times(1);
 }
 
-TEST(unique_ptr, get_test) {
-    auto ptr = new int{ 5 };
+TEST(unique_ptr, get) {
+    auto ptr = new int{5};
     auto smartPtr = UniquePointer<int>(ptr);
 
     EXPECT_EQ(ptr, smartPtr.get());
 }
 
-TEST(unique_ptr, reset_test) {
-    auto ptr = new int{ 5 };
+TEST(unique_ptr, reset) {
+    auto ptr = new int{5};
     auto smartPtr = UniquePointer<int>(ptr);
 
     smartPtr.reset(nullptr);
     EXPECT_EQ(nullptr, smartPtr.get());
 
-    auto otherPtr = new int{ 6 };
+    auto otherPtr = new int{6};
     smartPtr.reset(otherPtr);
     EXPECT_EQ(otherPtr, smartPtr.get());
 }
 
-TEST(unique_ptr, move_assigment_from_nullptr_to_nullptr) {
+TEST(unique_ptr, move_assignment_from_nullptr_to_nullptr) {
     auto testedSmartPtr = UniquePointer<TestObject>();
     auto otherSmartPtr = UniquePointer<TestObject>();
 
@@ -46,7 +59,7 @@ TEST(unique_ptr, move_assigment_from_nullptr_to_nullptr) {
     EXPECT_EQ(otherSmartPtr.get(), nullptr);
 }
 
-TEST(unique_ptr, move_assigment_from_nullptr_to_ptr) {
+TEST(unique_ptr, move_assignment_from_nullptr_to_ptr) {
     auto ptr = new TestObject();
     auto testedSmartPtr = UniquePointer<TestObject>();
     auto otherSmartPtr = UniquePointer<TestObject>(ptr);
@@ -59,7 +72,7 @@ TEST(unique_ptr, move_assigment_from_nullptr_to_ptr) {
     EXPECT_EQ(otherSmartPtr.get(), nullptr);
 }
 
-TEST(unique_ptr, move_assigment_from_ptr_to_nullptr) {
+TEST(unique_ptr, move_assignment_from_ptr_to_nullptr) {
     auto ptr = new TestObject();
     auto testedSmartPtr = UniquePointer<TestObject>(ptr);
     auto otherSmartPtr = UniquePointer<TestObject>();
@@ -72,7 +85,7 @@ TEST(unique_ptr, move_assigment_from_ptr_to_nullptr) {
     EXPECT_EQ(otherSmartPtr.get(), nullptr);
 }
 
-TEST(unique_ptr, move_assigment_from_ptr_to_ptr) {
+TEST(unique_ptr, move_assignment_from_ptr_to_ptr) {
     auto ptr = new TestObject();
     auto ptr2 = new TestObject();
     auto testedSmartPtr = UniquePointer<TestObject>(ptr);
@@ -106,4 +119,11 @@ TEST(unique_ptr, move_ctor_with_ptr) {
 
     EXPECT_EQ(testedSmartPtr.get(), ptr);
     EXPECT_EQ(otherSmartPtr.get(), nullptr);
+}
+
+TEST(unique_ptr, star_operator) {
+    auto ptr = new int{5};
+    auto smartPtr = UniquePointer<int>(ptr);
+
+    EXPECT_EQ(*ptr, *smartPtr.get());
 }

--- a/homework/unique_ptr/UniquePointer.hpp
+++ b/homework/unique_ptr/UniquePointer.hpp
@@ -4,11 +4,15 @@
 template <typename T>
 class UniquePointer {
 public:
-    using pointer = T*;
-    using element_type = T;
+    using Pointer = T*;
 
+private:
+    Pointer pointer_{nullptr};
+
+public:
     UniquePointer() = default;
-    explicit UniquePointer(pointer ptr)
+
+    explicit UniquePointer(Pointer ptr)
         : pointer_(ptr){};
 
     ~UniquePointer() noexcept {
@@ -17,29 +21,30 @@ public:
     }
 
     UniquePointer(const UniquePointer&) = delete;
+
     UniquePointer& operator=(const UniquePointer&) = delete;
 
     UniquePointer(UniquePointer&& other) noexcept {
         std::swap(pointer_, other.pointer_);
     }
 
+    const Pointer get() const noexcept {
+        return pointer_;
+    }
+
+    Pointer get() noexcept {
+        return pointer_;
+    }
+
+    void reset(Pointer ptr = Pointer()) noexcept {
+        delete pointer_;
+        pointer_ = ptr;
+    }
+
     UniquePointer& operator=(UniquePointer&& other) noexcept {
         reset();
         std::swap(pointer_, other.pointer_);
         return *this;
-    }
-
-    const pointer get() const noexcept {
-        return pointer_;
-    }
-
-    pointer get() noexcept {
-        return pointer_;
-    }
-
-    void reset(pointer ptr = pointer()) noexcept {
-        delete pointer_;
-        pointer_ = ptr;
     }
 
     const UniquePointer& operator*() const noexcept {
@@ -49,7 +54,4 @@ public:
     UniquePointer& operator*() noexcept {
         return *get();
     }
-
-private:
-    pointer pointer_{nullptr};
 };

--- a/homework/unique_ptr/UniquePointer.hpp
+++ b/homework/unique_ptr/UniquePointer.hpp
@@ -44,11 +44,11 @@ public:
     }
 
     const UniquePointer& operator*() const noexcept {
-        return *get();
+        return *this;
     }
 
     UniquePointer& operator*() noexcept {
-        return *get();
+        return *this;
     }
 
 private:

--- a/homework/unique_ptr/UniquePointer.hpp
+++ b/homework/unique_ptr/UniquePointer.hpp
@@ -5,6 +5,7 @@ template <typename T>
 class UniquePointer {
 public:
     using Pointer = T*;
+    using PointerToConst = const T*;
 
     UniquePointer() = default;
 
@@ -30,7 +31,7 @@ public:
         return *this;
     }
 
-    const Pointer get() const noexcept {
+    PointerToConst get() const noexcept {
         return pointer_;
     }
 

--- a/homework/unique_ptr/UniquePointer.hpp
+++ b/homework/unique_ptr/UniquePointer.hpp
@@ -45,11 +45,11 @@ public:
     }
 
     const UniquePointer& operator*() const noexcept {
-        return *this;
+        return *pointer_;
     }
 
     UniquePointer& operator*() noexcept {
-        return *this;
+        return *pointer_;
     }
 
 private:

--- a/homework/unique_ptr/UniquePointer.hpp
+++ b/homework/unique_ptr/UniquePointer.hpp
@@ -53,9 +53,13 @@ public:
         return *get();
     }
 
-    pointer operator->() const noexcept{
-	   return get();
-	} 
+    PointerToConst operator->() const noexcept {
+        return get();
+    }
+
+    Pointer operator->() noexcept {
+        return get();
+    }
 
 private:
     Pointer pointer_{nullptr};

--- a/homework/unique_ptr/UniquePointer.hpp
+++ b/homework/unique_ptr/UniquePointer.hpp
@@ -4,6 +4,7 @@
 template <typename T>
 class UniquePointer {
 public:
+    using ElementType = T;
     using Pointer = T*;
     using PointerToConst = const T*;
 
@@ -44,12 +45,12 @@ public:
         pointer_ = ptr;
     }
 
-    const UniquePointer& operator*() const noexcept {
-        return *pointer_;
+    const ElementType& operator*() const noexcept {
+        return *get();
     }
 
-    UniquePointer& operator*() noexcept {
-        return *pointer_;
+    ElementType& operator*() noexcept {
+        return *get();
     }
 
 private:

--- a/homework/unique_ptr/UniquePointer.hpp
+++ b/homework/unique_ptr/UniquePointer.hpp
@@ -6,10 +6,6 @@ class UniquePointer {
 public:
     using Pointer = T*;
 
-private:
-    Pointer pointer_{nullptr};
-
-public:
     UniquePointer() = default;
 
     explicit UniquePointer(Pointer ptr)
@@ -54,4 +50,7 @@ public:
     UniquePointer& operator*() noexcept {
         return *get();
     }
+
+private:
+    Pointer pointer_{nullptr};
 };

--- a/homework/unique_ptr/UniquePointer.hpp
+++ b/homework/unique_ptr/UniquePointer.hpp
@@ -24,6 +24,12 @@ public:
         std::swap(pointer_, other.pointer_);
     }
 
+    UniquePointer& operator=(UniquePointer&& other) noexcept {
+        reset();
+        std::swap(pointer_, other.pointer_);
+        return *this;
+    }
+
     const Pointer get() const noexcept {
         return pointer_;
     }
@@ -35,12 +41,6 @@ public:
     void reset(Pointer ptr = Pointer()) noexcept {
         delete pointer_;
         pointer_ = ptr;
-    }
-
-    UniquePointer& operator=(UniquePointer&& other) noexcept {
-        reset();
-        std::swap(pointer_, other.pointer_);
-        return *this;
     }
 
     const UniquePointer& operator*() const noexcept {

--- a/homework/unique_ptr/main.cpp
+++ b/homework/unique_ptr/main.cpp
@@ -1,8 +1,0 @@
-#include "UniquePointer.hpp"
-
-int main() {
-    int number{5};
-    UniquePointer<int> uniquePointer(int& number);
-
-    return 0;
-}


### PR DESCRIPTION
- fix star operator
- add unit tests for default c-tor, parametric c-tor, star operator
- change alias names
- remove main.cpp
- removed "_test" in test names for conformity
- "assigment" -> "assignment"
- minor formatting changes
- add const version of arrow operator